### PR TITLE
Added code to skip already solved boards

### DIFF
--- a/PopStarSolver/PopStarSolver.cpp
+++ b/PopStarSolver/PopStarSolver.cpp
@@ -12,6 +12,7 @@ int main()
 	SolveRandomPuzzle();
 //	SolveTwifirPuzzle();
 //	SolveFourFerPuzzle();
+//	SolveSolidPuzzle();
 	std::cout << "done" << std::endl;
 	return 0;
 }

--- a/Solver/ConcurrentQueue.h
+++ b/Solver/ConcurrentQueue.h
@@ -4,6 +4,7 @@
 #include <mutex>
 #include <queue>
 #include  <unordered_set>
+#include <unordered_map>
 namespace PopStarSolver
 {
 	template <class T>
@@ -59,5 +60,42 @@ namespace PopStarSolver
 		std::unordered_set<T> m_queue;
 		std::mutex m_mutex;
 
+	};
+	template <typename Key, typename T>
+	class ConcurrentUnorderd_Map
+	{
+	public:
+		void Insert(Key key, T& item)
+		{
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				std::pair<Key, T> insertValue(key, item);
+				m_queue.insert(insertValue);
+			}
+		}
+		bool Find(Key key, T& item)
+		{
+			{
+				std::lock_guard<std::mutex> lock(m_mutex);
+				std::unordered_map<Key, T>::iterator it = m_queue.find(key);
+				if (m_queue.end() != it)
+				{
+					item = it->second;
+					return true;
+				}
+				return false;
+			}
+		}
+
+		size_t Size()
+		{
+			std::lock_guard<std::mutex> lock(m_mutex);
+			return m_queue.size();
+		}
+
+
+	protected:
+		std::unordered_map<Key, T> m_queue;
+		std::mutex m_mutex;
 	};
 }

--- a/Solver/PuzzleSolution.h
+++ b/Solver/PuzzleSolution.h
@@ -3,7 +3,7 @@
 #include "PopStarBoad.h" //for PopStarBoard et al.
 #include <vector>
 #include "ConcurrentQueue.h"
-#include <unordered_set>
+
 
 namespace PopStarSolver
 {
@@ -88,7 +88,8 @@ namespace PopStarSolver
 		std::condition_variable m_process;
 		bool m_finished = false;
 
-		ConcurrentUnorderd_Set<BoardBitSet> m_finishedBoards;
+//		ConcurrentUnorderd_Set<BoardBitSet> m_finishedBoards;
+		ConcurrentUnorderd_Map<BoardBitSet, unsigned int> m_finishedBoards;
 
 		//post process solutions to determine if they're better than what I have
 		void ProcessSolutions();


### PR DESCRIPTION
I had commented out code that kept track of the board in an unordered
set and, if found, skipped the solving of the board. However I realized
this doesn't work because the solution could arrive at a board with a
higher score. This submission I witched to an unordered map and store
the score as well,  I ran this for a few minutes with some test outputs
and it eliminates a large chunk of the time. Although I still have yet
to get it to the point to where I can run it till its finished (I've had
it running in the background for a few hours and although it's processed
billions of solutions, it's still not done). Again, you get a good
answer in seconds and sometimes a better one in minutes. Occasionally
you'll get an improvement an hour in or so.
